### PR TITLE
Add readme path to kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,6 +1,7 @@
 multi:
     boards/central-hub:
         summary: the central hub of BeeHive
+        readme: README.md
         color: green
         site: https://github.com/isobianin/BeeHive
         bom: hardware/hub_PCB_redesign/1-click-bom.csv
@@ -10,6 +11,7 @@ multi:
             pcb: hardware/hub_PCB_redesign/beehive.kicad_pcb
     boards/8-switch-array:
         summary: an array of 8 individually addresseable NPN transistors
+        readme: README.md
         color: green
         site: https://github.com/isobianin/BeeHive
         bom: hardware/8_switch_array_(ver 2)/1-click-bom.csv
@@ -19,6 +21,7 @@ multi:
             pcb: hardware/8_switch_array_(ver 2)/8_switch_array.kicad_pcb
     boards/Peltier:
         summary:  A board containing an H-Bridge and a temperature sensor for peltier applications
+        readme: README.md
         color: green
         site: https://github.com/isobianin/BeeHive
         bom: hardware/peltier/1-click-bom.csv
@@ -28,6 +31,7 @@ multi:
             pcb: hardware/peltier/peltier.kicad_pcb
     boards/hp-led-switch:
         summary:  A board to control high powered leds
+        readme: README.md
         color: green
         site: https://github.com/isobianin/BeeHive
         bom: hardware/hp_led_switch/1-click-bom.csv


### PR DESCRIPTION
Looks like we are not picking this up without this at the moment. 